### PR TITLE
Add images folder

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,5 @@
+# Images Folder
+
+This folder contains images downloaded from the README.md file.
+
+Since the original image was a private GitHub user attachment (https://github.com/usar-attachments/assets/cacefc19-860b-43d2-9865-6336872b68a6), we weren't able to download it directly. You'll need to manually save it to this folder.


### PR DESCRIPTION
This PR creates an `images` folder in the repository to store images from the README.md file.

I attempted to download the image directly from the URL in the README, but it appears to be a private GitHub user attachment that requires authentication. You'll need to manually save the image to this folder.

Image URL found in README.md:
- https://github.com/usar-attachments/assets/cacefc19-860b-43d2-9865-6336872b68a6
