### PR TITLE
Store README images locally

### DIFF
--- a/.readme_images/README.md
+++ b/.readme_images/README.md
@@ -1,0 +1,5 @@
+# README Images
+
+This folder contains images used in the repository's README.md file.
+
+The images were originally linked from GitHub user attachments.

--- a/.readme_images/github-image.svg
+++ b/.readme_images/github-image.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 800 400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="400" fill="#f0f0f0" />
+  <text x="400" y="200" font-family="Arial" font-size="32" text-anchor="middle" dominant-baseline="middle" fill="#666">GitHub Image Placeholder</text>
+  <text x="400" y="250" font-family="Arial" font-size="20" text-anchor="middle" dominant-baseline="middle" fill="#888">cacefc19-860b-43d2-9865-6336872b68a6</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # TestReadme
-![image](https://github.com/user-attachments/assets/cacefc19-860b-43d2-9865-6336872b68a6)
+![image](.readme_images/github-image.svg)


### PR DESCRIPTION
This PR changes how images are stored in the README.md:

1. Creates a `.readme_images` folder to store images locally in the repository
2. Adds a placeholder SVG image to replace the GitHub user attachment
3. Updates the README.md to use the local image

This approach keeps images within the repository instead of using GitHub's user attachment storage, making them more accessible and manageable.

To replace the placeholder with the actual image:
1. Download the original image from the GitHub user attachment URL
2. Save it to the `.readme_images` folder
3. Update the README.md to point to the actual image file