### PR TITLE
Add .gitignore file for .meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore all .meta files
+*.meta


### PR DESCRIPTION
This PR adds a .gitignore file to exclude .meta files from version control.

Changes:
- Created a .gitignore file with a rule to ignore all files ending with .meta extension

This will prevent .meta files from being tracked by Git, keeping the repository cleaner and avoiding unnecessary file changes in commits.